### PR TITLE
VAAPI zero copy decoding

### DIFF
--- a/gui/include/avopenglwidget.h
+++ b/gui/include/avopenglwidget.h
@@ -11,6 +11,7 @@
 extern "C"
 {
 #include <libavcodec/avcodec.h>
+#include <libavutil/hwcontext_drm.h>
 }
 
 #define MAX_PANES 3
@@ -46,6 +47,7 @@ struct AVOpenGLFrame
 	ConversionConfig *conversion_config;
 
 	bool Update(AVFrame *frame, ChiakiLog *log);
+	bool UpdateDrmPrime(AVFrame *frame, ChiakiLog *log);
 };
 
 class AVOpenGLWidget: public QOpenGLWidget

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -61,6 +61,9 @@ int real_main(int argc, char *argv[])
 	QApplication::setApplicationDisplayName("chiaki4deck");
 	QApplication::setDesktopFileName("chiaki4deck");
 
+	// Needed for dmabuf import on X11
+	qputenv("QT_XCB_GL_INTEGRATION", "xcb_egl");
+
 	ChiakiErrorCode err = chiaki_lib_init();
 	if(err != CHIAKI_ERR_SUCCESS)
 	{

--- a/lib/src/ffmpegdecoder.c
+++ b/lib/src/ffmpegdecoder.c
@@ -157,7 +157,17 @@ hell:
 static AVFrame *pull_from_hw(ChiakiFfmpegDecoder *decoder, AVFrame *hw_frame)
 {
 	AVFrame *sw_frame = av_frame_alloc();
-	if(av_hwframe_transfer_data(sw_frame, hw_frame, 0) < 0)
+	if(hw_frame->format == AV_PIX_FMT_VAAPI)
+	{
+		sw_frame->format = AV_PIX_FMT_DRM_PRIME;
+		if(av_hwframe_map(sw_frame, hw_frame, AV_HWFRAME_MAP_READ) < 0)
+		{
+			CHIAKI_LOGE(decoder->log, "Failed to map hardware frame to DRM_PRIME");
+			av_frame_unref(sw_frame);
+			sw_frame = NULL;
+		}
+	}
+	else if(av_hwframe_transfer_data(sw_frame, hw_frame, 0) < 0)
 	{
 		CHIAKI_LOGE(decoder->log, "Failed to transfer frame from hardware");
 		av_frame_unref(sw_frame);


### PR DESCRIPTION
Import the decoded surface directly instead of reading it back to system memory and then uploading to GPU again.
Gives around 50% reduced CPU usage.