### PR TITLE
 Audio latency bounding

### DIFF
--- a/gui/include/streamsession.h
+++ b/gui/include/streamsession.h
@@ -174,6 +174,7 @@ class StreamSession : public QObject
 		SDL_AudioDeviceID audio_out;
 		SDL_AudioDeviceID audio_in;
 		size_t audio_out_sample_size;
+		bool audio_out_drain_queue;
 		unsigned int audio_buffer_size;
 #if CHIAKI_GUI_ENABLE_SPEEX
 		SpeexEchoState *echo_state;

--- a/gui/src/qml/SettingsDialog.qml
+++ b/gui/src/qml/SettingsDialog.qml
@@ -230,7 +230,6 @@ DialogView {
                     C.TextField {
                         Layout.preferredWidth: 400
                         text: Chiaki.settings.bitrate || ""
-                        validator: IntValidator { bottom: 0; top: 99999; }
                         placeholderText: {
                             var bitrate = 0;
                             switch (Chiaki.settings.resolution) {
@@ -347,7 +346,6 @@ DialogView {
 
                     C.TextField {
                         Layout.preferredWidth: 400
-                        validator: IntValidator { bottom: 0; top: 999999; }
                         text: Chiaki.settings.audioBufferSize || ""
                         placeholderText: qsTr("Default (9600)")
                         Material.accent: text && !validate() ? Material.Red : undefined

--- a/gui/src/qml/SettingsDialog.qml
+++ b/gui/src/qml/SettingsDialog.qml
@@ -347,7 +347,7 @@ DialogView {
                     C.TextField {
                         Layout.preferredWidth: 400
                         text: Chiaki.settings.audioBufferSize || ""
-                        placeholderText: qsTr("Default (9600)")
+                        placeholderText: qsTr("Default (5760)")
                         Material.accent: text && !validate() ? Material.Red : undefined
                         onEditingFinished: {
                             if (validate()) {
@@ -359,7 +359,7 @@ DialogView {
                         }
                         function validate() {
                             var num = parseInt(text);
-                            return num >= 1024 && num <= 0x20000;
+                            return num >= 1920 && num <= 19200;
                         }
                     }
 

--- a/gui/src/settings.cpp
+++ b/gui/src/settings.cpp
@@ -162,7 +162,7 @@ void Settings::SetCodec(ChiakiCodec codec)
 
 unsigned int Settings::GetAudioBufferSizeDefault() const
 {
-	return 9600;
+	return 5760;
 }
 
 unsigned int Settings::GetAudioBufferSizeRaw() const


### PR DESCRIPTION
Start dropping frames once the audio queue gets too big.
Also changed default buffer size and allowed range.

Default buffer size is now 3 frames (30 ms = 5760) which should
be reasonably safe value. Lowest accepted value is now 1 frame
(10ms = 1920).

This fixes possible runaway latency.

Closes #137