### PR TITLE
VideoReceiver: Parse H264 bitstream and skip decoding corrupted frames

### DIFF
--- a/lib/include/chiaki/videoreceiver.h
+++ b/lib/include/chiaki/videoreceiver.h
@@ -31,6 +31,7 @@ typedef struct chiaki_video_receiver_t
 
 	int32_t frames_lost;
 	int32_t reference_frames[16];
+	unsigned log2_max_frame_num;
 } ChiakiVideoReceiver;
 
 CHIAKI_EXPORT void chiaki_video_receiver_init(ChiakiVideoReceiver *video_receiver, struct chiaki_session_t *session, ChiakiPacketStats *packet_stats);

--- a/scripts/flatpak/0001-lavc-vaapi_h264-Fixup-invalid-references.patch
+++ b/scripts/flatpak/0001-lavc-vaapi_h264-Fixup-invalid-references.patch
@@ -1,0 +1,50 @@
+From 9d4b9b0b963f5375317636f4f527a203e21e89b9 Mon Sep 17 00:00:00 2001
+From: David Rosca <nowrep@gmail.com>
+Date: Mon, 8 Jan 2024 12:44:20 +0100
+Subject: [PATCH] lavc/vaapi_h264: Fixup invalid references
+
+---
+ libavcodec/vaapi_h264.c | 20 +++++++++++++++++++-
+ 1 file changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/libavcodec/vaapi_h264.c b/libavcodec/vaapi_h264.c
+index 55cf5a05ee..c935c88bad 100644
+--- a/libavcodec/vaapi_h264.c
++++ b/libavcodec/vaapi_h264.c
+@@ -128,6 +128,8 @@ static int fill_vaapi_ReferenceFrames(VAPictureParameterBufferH264 *pic_param,
+     DPB dpb;
+     int i;
+ 
++    const H264Picture *pic_good = NULL;
++
+     dpb.size     = 0;
+     dpb.max_size = FF_ARRAY_ELEMS(pic_param->ReferenceFrames);
+     dpb.va_pics  = pic_param->ReferenceFrames;
+@@ -136,7 +138,23 @@ static int fill_vaapi_ReferenceFrames(VAPictureParameterBufferH264 *pic_param,
+ 
+     for (i = 0; i < h->short_ref_count; i++) {
+         const H264Picture *pic = h->short_ref[i];
+-        if (pic && pic->reference && dpb_add(&dpb, pic) < 0)
++        if (!pic || !pic->reference)
++            continue;
++        if (pic->recovered) {
++            pic_good = pic;
++        } else {
++            if (pic_good) {
++                pic = pic_good;
++            } else {
++                for (int i = 0; i < h->short_ref_count; i++) {
++                    if (h->short_ref[i] && h->short_ref[i]->reference && h->short_ref[i]->recovered) {
++                        pic = h->short_ref[i];
++                        break;
++                    }
++                }
++            }
++        }
++        if (dpb_add(&dpb, pic) < 0)
+             return -1;
+     }
+ 
+-- 
+2.43.0
+

--- a/scripts/flatpak/chiaki4deck.yaml
+++ b/scripts/flatpak/chiaki4deck.yaml
@@ -121,6 +121,8 @@ modules:
         sha256: 488c76e57dd9b3bee901f71d5c95eaf1db4a5a31fe46a28654e837144207c270
       - type: patch
         path: 0001-lavc-vaapi_hevc-Fixup-invalid-references.patch
+      - type: patch
+        path: 0001-lavc-vaapi_h264-Fixup-invalid-references.patch
 
   - name: python3-google
     buildsystem: simple


### PR DESCRIPTION
Same logic as H265.

Also added ffmpeg vaapi patch, no more green with H264.