### PR TITLE
Add --profile option for multiple configuration profiles

### DIFF
--- a/gui/include/settings.h
+++ b/gui/include/settings.h
@@ -67,7 +67,7 @@ class Settings : public QObject
 		void SaveManualHosts();
 
 	public:
-		explicit Settings(QObject *parent = nullptr);
+		explicit Settings(const QString &conf, QObject *parent = nullptr);
 
 		bool GetDiscoveryEnabled() const		{ return settings.value("settings/auto_discovery", true).toBool(); }
 		void SetDiscoveryEnabled(bool enabled)	{ settings.setValue("settings/auto_discovery", enabled); }

--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -107,8 +107,6 @@ int real_main(int argc, char *argv[])
 	Application::setWindowIcon(QIcon(":/icons/chiaki4deck.svg"));
 #endif
 
-	Settings settings;
-
 	QCommandLineParser parser;
 	parser.setOptionsAfterPositionalArgumentsMode(QCommandLineParser::ParseAsPositionalArguments);
 	parser.addHelpOption();
@@ -124,6 +122,9 @@ int real_main(int argc, char *argv[])
 	parser.addPositionalArgument("nickname", "Needed for stream command to get credentials for connecting. "
 			"Use 'list' to get the nickname.");
 	parser.addPositionalArgument("host", "Address to connect to (when using the stream command).");
+
+	QCommandLineOption profile_option("profile", "", "profile", "Configuration profile");
+	parser.addOption(profile_option);
 
 	QCommandLineOption regist_key_option("registkey", "", "registkey");
 	parser.addOption(regist_key_option);
@@ -148,6 +149,8 @@ int real_main(int argc, char *argv[])
 
 	parser.process(app);
 	QStringList args = parser.positionalArguments();
+
+	Settings settings(parser.isSet(profile_option) ? parser.value(profile_option) : QString());
 
 	if(args.length() == 0)
 		return RunMain(app, &settings);

--- a/gui/src/settings.cpp
+++ b/gui/src/settings.cpp
@@ -2,6 +2,7 @@
 
 #include <settings.h>
 #include <QKeySequence>
+#include <QCoreApplication>
 
 #include <chiaki/config.h>
 
@@ -70,8 +71,10 @@ static void MigrateSettings(QSettings *settings)
 	}
 }
 
-Settings::Settings(QObject *parent) : QObject(parent)
+Settings::Settings(const QString &conf, QObject *parent) : QObject(parent),
+	settings(QCoreApplication::organizationName(), conf.isEmpty() ? QCoreApplication::applicationName() : QStringLiteral("%1-%2").arg(QCoreApplication::applicationName(), conf))
 {
+	settings.setFallbacksEnabled(false);
 	MigrateSettings(&settings);
 	manual_hosts_id_next = 0;
 	settings.setValue("version", SETTINGS_VERSION);


### PR DESCRIPTION
Useful for testing, but can also be used to work around some limitations
like no support for registering one console with multiple users or
using different settings for different consoles.

```
chiaki --profile test
```