### PR TITLE
Discovery delay

### DIFF
--- a/gui/include/discoverymanager.h
+++ b/gui/include/discoverymanager.h
@@ -64,6 +64,7 @@ class DiscoveryManager : public QObject
 
 		void SendWakeup(const QString &host, const QByteArray &regist_key, bool ps5);
 
+		bool GetActive() const { return service_active; }
 		const QList<DiscoveryHost> GetHosts() const;
 
 	signals:

--- a/gui/src/discoverymanager.cpp
+++ b/gui/src/discoverymanager.cpp
@@ -165,6 +165,7 @@ void DiscoveryManager::UpdateManualServices()
 
 		ChiakiDiscoveryServiceOptions options = {};
 		options.ping_ms = PING_MS;
+		options.ping_initial_ms = PING_MS;
 		options.hosts_max = 1;
 		options.host_drop_pings = DROP_PINGS;
 		options.cb = DiscoveryServiceHostsManualCallback;

--- a/gui/src/qmlbackend.cpp
+++ b/gui/src/qmlbackend.cpp
@@ -161,7 +161,7 @@ QList<QmlController*> QmlBackend::qmlControllers() const
 
 bool QmlBackend::discoveryEnabled() const
 {
-    return settings->GetDiscoveryEnabled();
+    return discovery_manager.GetActive();
 }
 
 void QmlBackend::setDiscoveryEnabled(bool enabled)

--- a/lib/include/chiaki/discoveryservice.h
+++ b/lib/include/chiaki/discoveryservice.h
@@ -17,6 +17,7 @@ typedef struct chiaki_discovery_service_options_t
 	size_t hosts_max;
 	uint64_t host_drop_pings;
 	uint64_t ping_ms;
+	uint64_t ping_initial_ms;
 	struct sockaddr *send_addr;
 	size_t send_addr_size;
 	char *send_host;

--- a/lib/src/discoveryservice.c
+++ b/lib/src/discoveryservice.c
@@ -127,12 +127,12 @@ static void *discovery_service_thread_func(void *user)
 	if(err != CHIAKI_ERR_SUCCESS)
 		goto beach;
 
-	while(true)
+	err = chiaki_bool_pred_cond_timedwait(&service->stop_cond, service->options.ping_initial_ms);
+
+	while(err == CHIAKI_ERR_TIMEOUT)
 	{
-		err = chiaki_bool_pred_cond_timedwait(&service->stop_cond, service->options.ping_ms);
-		if(err != CHIAKI_ERR_TIMEOUT)
-			break;
 		discovery_service_ping(service);
+		err = chiaki_bool_pred_cond_timedwait(&service->stop_cond, service->options.ping_ms);
 	}
 
 	chiaki_discovery_thread_stop(&discovery_thread);


### PR DESCRIPTION
This speeds up local discovery at launch. Also delay manual host discovery to make it less likely for auto connect to pick remote host.