### PR TITLE
Revert "CongestionControl: Disable reporting packet loss"

### DIFF
--- a/lib/include/chiaki/vl_rbsp.h
+++ b/lib/include/chiaki/vl_rbsp.h
@@ -260,14 +260,8 @@ vl_vlc_search_byte(struct vl_vlc *vlc, unsigned num_bits, uint8_t value)
 static inline void
 vl_vlc_removebits(struct vl_vlc *vlc, unsigned pos, unsigned num_bits)
 {
-#if defined(_MSC_VER)
-   /* MSVC Compiler defines unsigned long as 4 bytes so use explicit 64 bits mask */
    uint64_t lo = (vlc->buffer & (UINT64_MAX >> (pos + num_bits))) << num_bits;
    uint64_t hi = (vlc->buffer & (UINT64_MAX << (64 - pos)));
-#else
-   uint64_t lo = (vlc->buffer & (~0UL >> (pos + num_bits))) << num_bits;
-   uint64_t hi = (vlc->buffer & (~0UL << (64 - pos)));
-#endif
    vlc->buffer = lo | hi;
    vlc->invalid_bits += num_bits;
 }

--- a/lib/src/congestioncontrol.c
+++ b/lib/src/congestioncontrol.c
@@ -23,10 +23,9 @@ static void *congestion_control_thread_func(void *user)
 		chiaki_packet_stats_get(control->stats, true, &received, &lost);
 		ChiakiTakionCongestionPacket packet = { 0 };
 		packet.received = (uint16_t)received;
-		// packet.lost = (uint16_t)lost;
-		// FIXME: Bitrate never recovers when reporting packet loss
-		packet.received += (uint16_t)lost;
-		control->packet_loss = (double)lost / (received + lost);
+		packet.lost = (uint16_t)lost;
+		uint64_t total = received + lost;
+		control->packet_loss = total > 0 ? (double)lost / total : 0;
 		CHIAKI_LOGV(control->takion->log, "Sending Congestion Control Packet, received: %u, lost: %u",
 			(unsigned int)packet.received, (unsigned int)packet.lost);
 		chiaki_takion_send_congestion(control->takion, &packet);

--- a/lib/src/takion.c
+++ b/lib/src/takion.c
@@ -341,7 +341,10 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_takion_send_raw(ChiakiTakion *takion, const
 {
 	int r = send(takion->sock, buf, buf_size, 0);
 	if(r < 0)
+	{
+		CHIAKI_LOGE(takion->log, "Takion failed to send raw: %s", strerror(errno));
 		return CHIAKI_ERR_NETWORK;
+	}
 	return CHIAKI_ERR_SUCCESS;
 }
 


### PR DESCRIPTION
Also avoid divison by zero.

This reverts commit 75fa64ad1b5e89569f54d7a9ad8b9bdcc957670b.