### PR TITLE
Add UDP as needed port-forward

### DIFF
--- a/docs/setup/remoteconnection.md
+++ b/docs/setup/remoteconnection.md
@@ -16,7 +16,7 @@ Forward the ports for your console on your router following [this port forwardin
 
     | Port | Connection Type |
     | ---- | --------------- |
-    | 9295 | TCP             |
+    | 9295 | TCP & UDP       |
     | 9296 | UDP             |
     | 9297 | UDP             |
     | 9302 | UDP             |


### PR DESCRIPTION
When connecting remotely, based on Wireshark it sends both TCP & UDP to 9295. Only after updating port forwarding to forward both TCP and UDP it started to connect
It seems the 9295 UDP is only used during registration, but anyway, if it is not port-forwarded, then it isn't possible to add the PS5

<img width="1010" alt="image" src="https://github.com/streetpea/chiaki4deck/assets/472089/18d928f7-00b6-4e02-ad73-1be451548141">

Although I'm not a 100% sure if all 9295-9297 should be TCP & UDP, but 9295 definitely seems that way.

