### PR TITLE
Add CUDA and QSV to allowed decoder list

### DIFF
--- a/gui/src/qmlsettings.cpp
+++ b/gui/src/qmlsettings.cpp
@@ -241,6 +241,8 @@ QStringList QmlSettings::availableDecoders() const
 {
     static QSet<QString> allowed = {
         "vulkan",
+        "cuda",
+        "qsv",
 #if defined(Q_OS_LINUX)
         "vaapi",
 #elif defined(Q_OS_MACOS)


### PR DESCRIPTION
In the original Chiaki (and most of the Qt6 ports I've used), the entirety of the decoder list was added to this dropdown box. This allowed me to use CUDA and QSV on systems where I had access to these.

I've added CUDA and QSV to the allowed decoders list for all Operating Systems, as far as I'm aware these should both be available on Linux and Windows at the very least.

I've tested both CUDA and QSV by manually editing my saved registry values on Windows and both seem to work fine, I don't have easy access to a Linux device to test on there.

I'm happy to move these into the Windows and Linux blocks specifically to prevent macOS users from selecting it.

There are other decoders that could be enabled, such as DVXA2 (Windows-only) and OpenCL, however I'm unaware of either of these have any practical purpose now that Vulkan, VA-API and D3D11VA exist and are decent on most systems.