### PR TITLE
Enable Game Mode in MacOS

### DIFF
--- a/gui/MacOSXBundleInfo.plist.in
+++ b/gui/MacOSXBundleInfo.plist.in
@@ -28,5 +28,7 @@
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
 </dict>
 </plist>


### PR DESCRIPTION
MacOS 14 Sonoma introduced a new [Game Mode](https://support.apple.com/en-us/105118) that prioritizes performance and increases Bluetooth polling rates.

This PR sets the [`LSApplicationCategoryType` key](LSApplicationCategoryType) to the same value [that Moonlight uses](https://github.com/moonlight-stream/moonlight-qt/blob/3d8de56f251ad8ec4a237c1b59091697e8973c3a/app/Info.plist#L34) to enable this feature. This flag only matters on Sonoma, it will be ignored on older versions of MacOS.

This change only affects Macs, this has effect on non-Apple platforms.