### PR TITLE
Add missing QtQuick.Controls.Material imports

### DIFF
--- a/gui/src/qml/DialogView.qml
+++ b/gui/src/qml/DialogView.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
+import QtQuick.Controls.Material
 
 Item {
     id: dialog

--- a/gui/src/qml/RegistDialog.qml
+++ b/gui/src/qml/RegistDialog.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
+import QtQuick.Controls.Material
 
 import org.streetpea.chiaki4deck
 

--- a/gui/src/qml/controls/Button.qml
+++ b/gui/src/qml/controls/Button.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.Material
 
 Button {
     property bool firstInFocusChain: false


### PR DESCRIPTION
In a Plasma 6 desktop (tested on NixOS), chiaki4deck fails to launch with errors like
```
chiaki.gui: Component not ready
 QList(qrc:/Main.qml:171:9: Type ManualHostDialog unavailable
            ManualHostDialog { }
            ^, qrc:/ManualHostDialog.qml:9:1: Type DialogView unavailable
    DialogView {
    ^, qrc:/DialogView.qml:72:17: Non-existent attached object
                    Material.roundedScale: Material.SmallScale
                    ^)
```
This seems to be due to missing imports of `QtQuick.Controls.Material` in a few spots -- `Material` is used but not explicitly imported, resulting in the errors. This PR adds the missing imports.

I am able to launch chiaki4deck successfully (and get into a session with a PS5) with these changes.
