### PR TITLE
Fix libplacebo patch in MSVC build

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -15,6 +15,7 @@ jobs:
       vcpkg_baseline: 42bb0d9e8d4cf33485afb9ee2229150f79f61a1f
       VCPKG_INSTALLED_DIR: ./vcpkg_installed/
       dep_folder: deps
+      libplacebo_tag: 311a59507f6a0465aaac9b783af65bf349755360
 
     defaults:
       run:
@@ -110,6 +111,7 @@ jobs:
         run: |
           git clone --recursive https://github.com/haasn/libplacebo.git
           cd libplacebo
+          git checkout ${{ env.libplacebo_tag }}
           meson setup `
           --prefix "${{ github.workspace }}\${{ env.dep_folder }}" `
           --native-file ../meson.ini `

--- a/scripts/windows-vc/libplacebo-pc.patch
+++ b/scripts/windows-vc/libplacebo-pc.patch
@@ -1,12 +1,9 @@
 diff --git a/deps/lib/pkgconfig/libplacebo.pc b/deps/lib/pkgconfig/libplacebo.pc
-index 9d7e7ee..f95b069 100644
+index 561cafc..e77f8f5 100644
 --- a/deps/lib/pkgconfig/libplacebo.pc
 +++ b/deps/lib/pkgconfig/libplacebo.pc
-@@ -18,6 +18,6 @@ Name: libplacebo
- Description: Reusable library for GPU-accelerated video/image rendering
- Version: 7.342.0
+@@ -20,3 +20,3 @@ Version: 7.346.0
  Requires.private: shaderc >= 2019.1, spirv-cross-c-shared >= 0.29.0, vulkan, lcms2 >= 2.9
 -Libs: -L${libdir} -lplacebo
 +Libs: -L${libdir} -llibplacebo
  Libs.private: -lshlwapi -lversion
- Cflags: -I${includedir}


### PR DESCRIPTION
- Reduces the patch context for the libplacebo patch so that it doesn't fail when libplacebo's version number changes
- Lock libplacebo to a specific tag like the msys2 build