### PR TITLE
lib: Reset thread to 0 instead of NULL to fix Linux build

### DIFF
--- a/lib/src/congestioncontrol.c
+++ b/lib/src/congestioncontrol.c
@@ -66,7 +66,7 @@ CHIAKI_EXPORT ChiakiErrorCode chiaki_congestion_control_stop(ChiakiCongestionCon
 	err = chiaki_thread_join(&control->thread, NULL);
 	if(err != CHIAKI_ERR_SUCCESS)
 		return err;
-	control->thread.thread = NULL;
+	control->thread.thread = 0;
 
 	return chiaki_bool_pred_cond_fini(&control->stop_cond);
 }


### PR DESCRIPTION
assignment to ‘pthread_t’ {aka ‘long unsigned int’} from ‘void *’ makes integer from pointer without a cast.