### PR TITLE
Set SDL application name so the application name appears in volume controls

### DIFF
--- a/gui/src/main.cpp
+++ b/gui/src/main.cpp
@@ -81,6 +81,8 @@ int real_main(int argc, char *argv[])
 		return 1;
 	}
 
+    SDL_SetHint(SDL_HINT_APP_NAME, "chiaki4deck");
+
 	if(SDL_Init(SDL_INIT_AUDIO) < 0)
 	{
 		fprintf(stderr, "SDL Audio init failed: %s\n", SDL_GetError());


### PR DESCRIPTION
Currently no SDL application name is set so volume controls on Linux distributions using Pipewire currently display the default of "SDL Application"

Before:

![image](https://github.com/streetpea/chiaki4deck/assets/442287/e29c7f85-2a4e-4f9b-9bbb-d5b259dcfc88)

After:

![image](https://github.com/streetpea/chiaki4deck/assets/442287/1402c33c-9ce4-466f-9604-f1a640eee53e)

Unfortunately no way to get an icon here without using SDL3, but apparently switching to SDL3 should mean it will just use the .desktop file icon, but it can also be set with a similar hint `SDL_HINT_AUDIO_DEVICE_APP_ICON_NAME`